### PR TITLE
docs(github): add github related templates and contributing guide

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -1,0 +1,55 @@
+
+# Commit Message Convention
+
+This document describes the commit message format to keep a clean and consistent history.
+
+---
+
+## Format
+
+```
+<type>(<scope>): <subject>
+```
+
+- **type**: The type of change
+- **scope**: The area of the code affected (optional but recommended)
+- **subject**: A short description of the change (imperative mood, no period)
+
+---
+
+## Types
+
+| Type   | Description                       | Example                      |
+|--------|---------------------------------|------------------------------|
+| feat   | A new feature                   | feat(about): add i18n support |
+| fix    | A bug fix                      | fix(header): fix mobile layout issue |
+| docs   | Documentation only             | docs(readme): update usage instructions |
+| chore  | Routine tasks (build, CI, deps) | chore(docker): update base image version |
+| test   | Adding or fixing tests         | test(backend): add unit tests for user service |
+| refactor | Code changes that neither fix a bug nor add a feature | refactor(frontend): simplify header component |
+
+---
+
+## Rules
+
+- Use **imperative mood** in the subject (e.g., “fix”, not “fixed” or “fixes”)
+- Keep the subject **short and clear** (50 characters or less preferred)
+- No period (`.`) at the end of the subject
+- Use lowercase for type and scope
+- Separate type and scope with parentheses and a colon as shown
+- If no scope, omit parentheses: `feat: add login`
+
+---
+
+## Examples
+
+```
+feat(about): add multilingual support  
+fix(navbar): correct dropdown behaviour  
+docs: update README with setup instructions  
+chore: update dependencies  
+test(api): add integration tests for endpoints  
+refactor(auth): clean up login logic
+```
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: 🐛 Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: Narae-H
+---
+
+## Description
+- Please describe what the bug is.
+
+## To Reproduce
+- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behaviour
+- A clear description of what you expected to happen.
+
+## Actual Behaviour
+- What actually happened.
+
+## Screenshots (If applicable)
+- Add screenshots to help explain your problem.
+
+## Related Branch  
+- bugfix/#issue-number-short-description (update when branch is created)
+
+## Environment (please complete the following information):
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+## Additional context (If applicable)
+- Add any other context about the problem here.
+
+## Checklist
+- [ ] Bug reproduction verified  
+- [ ] Root cause analysis completed  
+- [ ] Bug fixed  
+- [ ] Fix tested  
+- [ ] Code review requested  
+- [ ] Fix merged into develop  
+- [ ] Issue closed

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: ✨ Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: []
+assignees: Narae-H
+---
+
+## Description
+- Please describe the feature you would like to see.
+
+## Related Branch
+- feature/#issue-number-short-description (update when branch is created)
+
+## Checklist
+- [ ] Task understanding confirmed
+- [ ] Branch created
+- [ ] Development started
+- [ ] Code review requested
+- [ ] Tests passed
+- [ ] Merged into develop
+- [ ] Closed issue

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: 📋 Task
+about: Describe a general task or to-do item
+title: "[TASK] "
+labels: task
+assignees: Narae-H
+---
+
+## Description
+- Please describe the task in detail.
+
+## Related Branch
+- feature/#issue-number-short-description (update when branch is created)
+
+## Additional notes (If applicable)
+- Include any relevant information, links, or context.
+
+## Checklist
+- [ ] Task understanding confirmed
+- [ ] Closed issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+- Briefly describe what this PR does.
+
+## Related Issue
+- Closes #issue-number
+
+## Changes
+- List key changes made in this PR
+
+## Checklist
+- [ ] Code builds successfully
+- [ ] Tests added or updated
+- [ ] Documentation updated if needed
+- [ ] Reviewer assigned


### PR DESCRIPTION
## Summary
- Added GitHub-related templates to improve collaboration and maintain consistency in issue tracking and commit history.

## Related Issue
- Closes #1 

## Changes
- Added `bug_report.md`, `feature_request.md`, `task.md` to `.github/ISSUE_TEMPLATE/`
- Created `COMMIT_CONVENTION.md` for consistent commit messages
- Added `PULL_REQUEST_TEMPLATE.md`

## Checklist
- [x] Code builds successfully
- [x] Documentation updated if needed
- [x] Reviewer assigned
